### PR TITLE
chore: do heavy lifting in trait default impl, cut scope in concrete impls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check (All features)
         run: cargo check --all-features
@@ -45,13 +39,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Lint
         run: cargo fmt --all --check
@@ -69,13 +57,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         # need the release flag to test rln integration appropriately

--- a/src/bls12_377_impl.rs
+++ b/src/bls12_377_impl.rs
@@ -1,34 +1,10 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_bls12_377::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
 use ark_bls12_377::{Fq, Fr, G1Affine, G1Projective};
 
-#[allow(non_camel_case_types)]
-pub struct Bls12_377_G1Affine(G1Affine);
-impl AffineWrapper for Bls12_377_G1Affine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        Bls12_377_G1Affine(G1Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G1_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G1_GENERATOR_Y
-    }
-}
-
-impl From<Bls12_377_G1Affine> for G1Projective {
-    fn from(value: Bls12_377_G1Affine) -> Self {
-        G1Projective::from(value.0)
-    }
-}
-
 impl StealthAddressOnCurve for ark_bls12_377::Bls12_377 {
     type Projective = G1Projective;
-    type Affine = Bls12_377_G1Affine;
     type Fr = Fr;
 }
 

--- a/src/bls12_377_impl.rs
+++ b/src/bls12_377_impl.rs
@@ -1,7 +1,7 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_bls12_377::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
-use ark_bls12_377::{Fq, Fr, G1Affine, G1Projective};
+
+use ark_bls12_377::{Fr, G1Projective};
 
 impl StealthAddressOnCurve for ark_bls12_377::Bls12_377 {
     type Projective = G1Projective;

--- a/src/bls12_381_impl.rs
+++ b/src/bls12_381_impl.rs
@@ -1,34 +1,10 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_bls12_381::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
 use ark_bls12_381::{Fq, Fr, G1Affine, G1Projective};
 
-#[allow(non_camel_case_types)]
-pub struct Bls12_381_G1Affine(G1Affine);
-impl AffineWrapper for Bls12_381_G1Affine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        Bls12_381_G1Affine(G1Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G1_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G1_GENERATOR_Y
-    }
-}
-
-impl From<Bls12_381_G1Affine> for G1Projective {
-    fn from(value: Bls12_381_G1Affine) -> Self {
-        G1Projective::from(value.0)
-    }
-}
-
 impl StealthAddressOnCurve for ark_bls12_381::Bls12_381 {
     type Projective = G1Projective;
-    type Affine = Bls12_381_G1Affine;
     type Fr = Fr;
 }
 

--- a/src/bls12_381_impl.rs
+++ b/src/bls12_381_impl.rs
@@ -1,7 +1,7 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_bls12_381::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
-use ark_bls12_381::{Fq, Fr, G1Affine, G1Projective};
+
+use ark_bls12_381::{Fr, G1Projective};
 
 impl StealthAddressOnCurve for ark_bls12_381::Bls12_381 {
     type Projective = G1Projective;

--- a/src/bn254_impl.rs
+++ b/src/bn254_impl.rs
@@ -1,7 +1,7 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_bn254::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
-use ark_bn254::{Fq, Fr, G1Affine, G1Projective};
+
+use ark_bn254::{Fr, G1Projective};
 use rln::hashers::{hash_to_field, poseidon_hash};
 
 impl StealthAddressOnCurve for ark_bn254::Bn254 {

--- a/src/bn254_impl.rs
+++ b/src/bn254_impl.rs
@@ -1,27 +1,11 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_bn254::g1::{G1_GENERATOR_X, G1_GENERATOR_Y};
 use ark_bn254::{Fq, Fr, G1Affine, G1Projective};
 use rln::hashers::{hash_to_field, poseidon_hash};
 
-impl AffineWrapper for G1Affine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        G1Affine::new(x, y)
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G1_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G1_GENERATOR_Y
-    }
-}
-
 impl StealthAddressOnCurve for ark_bn254::Bn254 {
     type Projective = G1Projective;
-    type Affine = G1Affine;
     type Fr = Fr;
 
     fn hash_to_fr(input: &[u8]) -> Self::Fr {

--- a/src/pallas_impl.rs
+++ b/src/pallas_impl.rs
@@ -1,6 +1,6 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_pallas::{Affine, Fq, Fr, Projective, G_GENERATOR_X, G_GENERATOR_Y};
+use ark_pallas::{Fr, Projective};
 
 pub struct Pallas;
 

--- a/src/pallas_impl.rs
+++ b/src/pallas_impl.rs
@@ -1,35 +1,11 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_pallas::{Affine, Fq, Fr, Projective, G_GENERATOR_X, G_GENERATOR_Y};
-
-#[allow(non_camel_case_types)]
-pub struct PallasAffine(Affine);
-impl AffineWrapper for PallasAffine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        PallasAffine(Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G_GENERATOR_Y
-    }
-}
-
-impl From<PallasAffine> for Projective {
-    fn from(value: PallasAffine) -> Self {
-        Projective::from(value.0)
-    }
-}
 
 pub struct Pallas;
 
 impl StealthAddressOnCurve for Pallas {
     type Projective = Projective;
-    type Affine = PallasAffine;
     type Fr = Fr;
 }
 

--- a/src/secp256k1_impl.rs
+++ b/src/secp256k1_impl.rs
@@ -1,36 +1,11 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
-use ark_secp256k1::{Affine, Fq, Fr, Projective};
-use ark_secp256k1::{G_GENERATOR_X, G_GENERATOR_Y};
-
-#[allow(non_camel_case_types)]
-pub struct Secp256k1_Affine(Affine);
-impl AffineWrapper for Secp256k1_Affine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        Secp256k1_Affine(Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G_GENERATOR_Y
-    }
-}
-
-impl From<Secp256k1_Affine> for Projective {
-    fn from(value: Secp256k1_Affine) -> Self {
-        Projective::from(value.0)
-    }
-}
+use crate::stealth_commitments::StealthAddressOnCurve;
+use ark_secp256k1::{Fr, Projective};
 
 pub struct Secp256k1;
 
 impl StealthAddressOnCurve for Secp256k1 {
     type Projective = Projective;
-    type Affine = Secp256k1_Affine;
     type Fr = Fr;
 }
 

--- a/src/secp256r1_impl.rs
+++ b/src/secp256r1_impl.rs
@@ -1,6 +1,6 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_secp256r1::{Affine, Fq, Fr, Projective};
+use ark_secp256r1::{Fr, Projective};
 
 pub struct Secp256r1;
 

--- a/src/secp256r1_impl.rs
+++ b/src/secp256r1_impl.rs
@@ -1,36 +1,11 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_secp256r1::{Affine, Fq, Fr, Projective};
-use ark_secp256r1::{G_GENERATOR_X, G_GENERATOR_Y};
-
-#[allow(non_camel_case_types)]
-pub struct Secp256r1_Affine(Affine);
-impl AffineWrapper for Secp256r1_Affine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        Secp256r1_Affine(Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G_GENERATOR_Y
-    }
-}
-
-impl From<Secp256r1_Affine> for Projective {
-    fn from(value: Secp256r1_Affine) -> Self {
-        Projective::from(value.0)
-    }
-}
 
 pub struct Secp256r1;
 
 impl StealthAddressOnCurve for Secp256r1 {
     type Projective = Projective;
-    type Affine = Secp256r1_Affine;
     type Fr = Fr;
 }
 

--- a/src/vesta_impl.rs
+++ b/src/vesta_impl.rs
@@ -1,6 +1,6 @@
 use crate::define_curve_tests;
 use crate::stealth_commitments::StealthAddressOnCurve;
-use ark_vesta::{Affine, Fq, Fr, Projective, G_GENERATOR_X, G_GENERATOR_Y};
+use ark_vesta::{Fr, Projective};
 
 pub struct Vesta;
 

--- a/src/vesta_impl.rs
+++ b/src/vesta_impl.rs
@@ -1,35 +1,11 @@
 use crate::define_curve_tests;
-use crate::stealth_commitments::{AffineWrapper, StealthAddressOnCurve};
+use crate::stealth_commitments::StealthAddressOnCurve;
 use ark_vesta::{Affine, Fq, Fr, Projective, G_GENERATOR_X, G_GENERATOR_Y};
-
-#[allow(non_camel_case_types)]
-pub struct VestaAffine(Affine);
-impl AffineWrapper for VestaAffine {
-    type Fq = Fq;
-    fn new(x: Self::Fq, y: Self::Fq) -> Self {
-        VestaAffine(Affine::new(x, y))
-    }
-
-    fn get_generator_x() -> Self::Fq {
-        G_GENERATOR_X
-    }
-
-    fn get_generator_y() -> Self::Fq {
-        G_GENERATOR_Y
-    }
-}
-
-impl From<VestaAffine> for Projective {
-    fn from(value: VestaAffine) -> Self {
-        Projective::from(value.0)
-    }
-}
 
 pub struct Vesta;
 
 impl StealthAddressOnCurve for Vesta {
     type Projective = Projective;
-    type Affine = VestaAffine;
     type Fr = Fr;
 }
 


### PR DESCRIPTION
Tighter integration with arkworks, use `CurveGroup` trait to simplify operations
