### PR TITLE
chore(StealthAddressOnCurve): reuse scalar field from Projective

### DIFF
--- a/sdk/src/baby_jub_jub_impl.rs
+++ b/sdk/src/baby_jub_jub_impl.rs
@@ -6,7 +6,6 @@ pub struct BabyJubJub;
 
 impl StealthAddressOnCurve for BabyJubJub {
     type Projective = EdwardsProjective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/bls12_377_impl.rs
+++ b/sdk/src/bls12_377_impl.rs
@@ -4,7 +4,6 @@ use ark_bls12_377::{Bls12_377, Fr, G1Projective};
 
 impl StealthAddressOnCurve for Bls12_377 {
     type Projective = G1Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/bls12_381_impl.rs
+++ b/sdk/src/bls12_381_impl.rs
@@ -4,7 +4,6 @@ use ark_bls12_381::{Bls12_381, Fr, G1Projective};
 
 impl StealthAddressOnCurve for Bls12_381 {
     type Projective = G1Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/bn254_impl.rs
+++ b/sdk/src/bn254_impl.rs
@@ -3,7 +3,6 @@ use ark_bn254::{Bn254, Fr, G1Projective};
 
 impl StealthAddressOnCurve for Bn254 {
     type Projective = G1Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/bw6_761_impl.rs
+++ b/sdk/src/bw6_761_impl.rs
@@ -4,7 +4,6 @@ use ark_bw6_761::{Fr, G1Projective, BW6_761};
 
 impl StealthAddressOnCurve for BW6_761 {
     type Projective = G1Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/pallas_impl.rs
+++ b/sdk/src/pallas_impl.rs
@@ -6,7 +6,6 @@ pub struct Pallas;
 
 impl StealthAddressOnCurve for Pallas {
     type Projective = Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/secp256k1_impl.rs
+++ b/sdk/src/secp256k1_impl.rs
@@ -6,7 +6,6 @@ pub struct Secp256k1;
 
 impl StealthAddressOnCurve for Secp256k1 {
     type Projective = Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/secp256r1_impl.rs
+++ b/sdk/src/secp256r1_impl.rs
@@ -6,7 +6,6 @@ pub struct Secp256r1;
 
 impl StealthAddressOnCurve for Secp256r1 {
     type Projective = Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]

--- a/sdk/src/vesta_impl.rs
+++ b/sdk/src/vesta_impl.rs
@@ -6,7 +6,6 @@ pub struct Vesta;
 
 impl StealthAddressOnCurve for Vesta {
     type Projective = Projective;
-    type Fr = Fr;
 }
 
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
Reuses the scalar field from the Projective trait's associated type instead of passing it on our own to avoid misconfigurations 
