### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Stealth Address Kit: A Rust library for generating stealth addresses."
 license = "MIT"
 homepage = "https://vac.dev"
+repository = "https://github.com/vacp2p/stealth-address-kit"
 
 [lib]
 name = "stealth_address_kit"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.