### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "stealth_address_kit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "stealth_address_kit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stealth_address_kit"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Stealth Address Kit: A Rust library for generating stealth addresses."
 license = "MIT"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "stealth_address_kit"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Stealth Address Kit: A Rust library for generating stealth addresses."
 license = "MIT"
 homepage = "https://vac.dev"
 repository = "https://github.com/vacp2p/stealth-address-kit"
+readme = "../README.md"
 
 [lib]
 name = "stealth_address_kit"


### PR DESCRIPTION
The release includes changes to the api. However, we are not stable (audited) yet, and therefore, we cannot release v1. This minor release will suffice to change the trait and its impl.
